### PR TITLE
Removing reference to obdcClose()

### DIFF
--- a/using SMRA with R.md
+++ b/using SMRA with R.md
@@ -143,9 +143,9 @@ Wrapping the dbConnect function inside the suppressWarnings function prevents yo
 
 ## Close the connection
 
-At the end of the session close the channel using:
+At the end of the session close the channel by removing the object:
 
-    odbcClose(channel)
+    rm(channel)
 
 # Views and variables in SMRA
 

--- a/using SMRA with R.md
+++ b/using SMRA with R.md
@@ -143,8 +143,9 @@ Wrapping the dbConnect function inside the suppressWarnings function prevents yo
 
 ## Close the connection
 
-At the end of the session close the channel by removing the object:
+At the end of the session close the channel and remove the object:
 
+    dbDisconnect(channel)
     rm(channel)
 
 # Views and variables in SMRA


### PR DESCRIPTION
obdcClose() is not from the obdc library and so does not work in the example shown.