### PR TITLE
Add question 'Where are all my packages?' and an answer to this question.

### DIFF
--- a/posit_team_applications_faq.md
+++ b/posit_team_applications_faq.md
@@ -12,6 +12,10 @@ This document aims to answer frequently asked questions from users in relation t
 
 ### Installing Packages
 
+#### Where are all my packages?
+
+Unlike the old RStudio Server Pro environment, there are no pre-installed packages in Posit Workbench.  This gives you full control over what packages, and versions of packages, you want to use, rather than those dictated by the administrator.
+
 #### How do I install the `{phsmethods}` package?
 
 The `{phsmethods}` package has a dependency on the the `{gdata}` package.  The `{gdata}` package cannot be installed as a pre-compiled binary; attempting this gives an error.  Therefore, you need to force R to install the source version by specifying the URL for the source version of packages on Package Manager: 


### PR DESCRIPTION
This follows a beginner user asking why they couldn't use the {rstudioapi} package: because it wasn't installed first.